### PR TITLE
Add request timeout option to everything

### DIFF
--- a/pbclient/__init__.py
+++ b/pbclient/__init__.py
@@ -36,24 +36,26 @@ def _pybossa_req(method, domain, id=None, payload=None, params={},
     code of the response.
     """
     url = _opts['endpoint'] + '/api/' + domain
+    timeout = _opts.get('timeout')
     if id is not None:
         url += '/' + str(id)
     if 'api_key' in _opts:
         params['api_key'] = _opts['api_key']
     if method == 'get':
-        r = requests.get(url, params=params)
+        r = requests.get(url, params=params, timeout=timeout)
     elif method == 'post':
         if files is None and headers['content-type'] == 'application/json':
             r = requests.post(url, params=params, headers=headers,
-                              data=json.dumps(payload))
+                              data=json.dumps(payload), timeout=timeout)
         else:
-            r = requests.post(url, params=params, files=files, data=payload)
+            r = requests.post(url, params=params, files=files, data=payload,
+                              timeout=timeout)
     elif method == 'put':
         r = requests.put(url, params=params, headers=headers,
-                         data=json.dumps(payload))
+                         data=json.dumps(payload), timeout=timeout)
     elif method == 'delete':
         r = requests.delete(url, params=params, headers=headers,
-                            data=json.dumps(payload))
+                            data=json.dumps(payload), timeout=timeout)
     if r.status_code / 100 == 2:
         if r.text and r.text != '""':
             return json.loads(r.text)


### PR DESCRIPTION
Right now there are no timeouts on any of the API requests. I've added the ``timeout`` option on the global state which sets the ``requests`` package timeout argument on all the calls.

I can add a short documentation sentence about it to the readme, perhaps in the "On queries and performance" section?

Regarding tests, I'm unsure on how to add sensible ones.